### PR TITLE
Prepare for npm publish as @contedra/astro-loader-firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,12 @@ Astro Content Layer loader for Firestore.
 
 Loads content from a Conteditor-managed Firestore collection and exposes it through Astro's Content Layer API (v5+).
 
-## Installation                                                                                                          
-                                                                  
-This package is not yet published to npm. Use a git URL or local reference:
-                                                                           
+## Installation
+
 ```bash
-# Git URL
-pnpm add github:contedra/astro-loader-firestore
-                                               
-# Or local reference (in a pnpm workspace)                                                                               
-# package.json: "@contedra/astro-loader-firestore": "workspace:*"
+npm install @contedra/astro-loader-firestore
+# or
+pnpm add @contedra/astro-loader-firestore
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
   ],
   "author": "",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/contedra/astro-loader-firestore.git"
+  },
   "peerDependencies": {
     "astro": "^5.0.0"
   },


### PR DESCRIPTION
## Summary
- Add `repository` field to package.json pointing to GitHub repo
- Update README installation instructions from git URL to `npm install @contedra/astro-loader-firestore`

Closes #3

## Notes
- npm publish itself is out of scope for this PR — repo owner will manually create the `@contedra` npm org and run `npm publish --access public`
- Build verified (`pnpm build` succeeds), `npm publish --dry-run` confirmed package contents are correct (dist/*, LICENSE, README.md, package.json)

## Test plan
- [ ] Verify `pnpm build` succeeds
- [ ] Verify `npm publish --dry-run` shows expected package contents
- [ ] After merge, owner publishes to npm and verifies with `npm info @contedra/astro-loader-firestore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)