### PR TITLE
[AI] chore: update repository URLs after rename to toolkit

### DIFF
--- a/packages/astro-loader-firestore/package.json
+++ b/packages/astro-loader-firestore/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/contedra/astro-loader-firestore",
+    "url": "https://github.com/contedra/toolkit",
     "directory": "packages/astro-loader-firestore"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/contedra/astro-loader-firestore",
+    "url": "https://github.com/contedra/toolkit",
     "directory": "packages/core"
   },
   "dependencies": {

--- a/packages/md-importer/package.json
+++ b/packages/md-importer/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/contedra/astro-loader-firestore",
+    "url": "https://github.com/contedra/toolkit",
     "directory": "packages/md-importer"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Updated `repository.url` in all three package.json files (`packages/core`, `packages/astro-loader-firestore`, `packages/md-importer`) from `contedra/astro-loader-firestore` to `contedra/toolkit`
- Verified no stale repo URLs remain in README.md files

## Test plan
- [x] Confirmed all three package.json files now point to `https://github.com/contedra/toolkit`
- [x] Grep confirmed no remaining references to the old repo URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)