### PR TITLE
[AI] closed #25 fix: asset download cache should verify file integrity via md5 hash

### DIFF
--- a/packages/core/src/__tests__/downloadAsset.test.ts
+++ b/packages/core/src/__tests__/downloadAsset.test.ts
@@ -90,6 +90,20 @@ describe("downloadAsset (md5 cache verification)", () => {
     expect(cached).toEqual(newContent);
   });
 
+  it("should reuse cached file when metadata has no md5Hash", async () => {
+    const content = Buffer.from("cached-content");
+    const cachedPath = path.join(cacheDir, "model/doc/image.png");
+    mkdirSync(path.dirname(cachedPath), { recursive: true });
+    writeFileSync(cachedPath, content);
+
+    mockGetMetadata.mockResolvedValue([{ md5Hash: undefined }]);
+
+    const result = await downloadAsset(fakeApp, "model/doc/image.png", cacheDir);
+
+    expect(result).toBe(false);
+    expect(mockDownload).not.toHaveBeenCalled();
+  });
+
   it("should reuse cached file when getMetadata fails", async () => {
     const content = Buffer.from("cached-content");
     const cachedPath = path.join(cacheDir, "model/doc/image.png");

--- a/packages/core/src/__tests__/downloadAsset.test.ts
+++ b/packages/core/src/__tests__/downloadAsset.test.ts
@@ -120,6 +120,23 @@ describe("downloadAsset (md5 cache verification)", () => {
     expect(readFileSync(cachedPath)).toEqual(content);
   });
 
+  it("should re-download when cached file is unreadable", async () => {
+    // Create a directory where a file is expected, making readFileSync fail
+    const cachedPath = path.join(cacheDir, "model/doc/image.png");
+    mkdirSync(cachedPath, { recursive: true });
+
+    const newContent = Buffer.from("fresh-download");
+    mockDownload.mockResolvedValue([newContent]);
+
+    // readFileSync throws EISDIR, localMd5 becomes empty, falls through to download.
+    // writeFile also throws EISDIR since cachePath is a directory,
+    // so the function propagates the error (expected for truly broken cache entries).
+    await expect(
+      downloadAsset(fakeApp, "model/doc/image.png", cacheDir)
+    ).rejects.toThrow();
+    expect(mockDownload).toHaveBeenCalledOnce();
+  });
+
   it("should not create additional metadata files in cache directory", async () => {
     const content = Buffer.from("file-content");
     mockDownload.mockResolvedValue([content]);

--- a/packages/core/src/__tests__/downloadAsset.test.ts
+++ b/packages/core/src/__tests__/downloadAsset.test.ts
@@ -121,20 +121,25 @@ describe("downloadAsset (md5 cache verification)", () => {
   });
 
   it("should re-download when cached file is unreadable", async () => {
-    // Create a directory where a file is expected, making readFileSync fail
+    // Simulate an unreadable cache by writing a file, then changing its
+    // permissions to 0 (write-only) so readFileSync throws EACCES.
     const cachedPath = path.join(cacheDir, "model/doc/image.png");
-    mkdirSync(cachedPath, { recursive: true });
+    mkdirSync(path.dirname(cachedPath), { recursive: true });
+    writeFileSync(cachedPath, Buffer.from("corrupt"));
+    const { chmodSync } = await import("node:fs");
+    chmodSync(cachedPath, 0o000);
 
     const newContent = Buffer.from("fresh-download");
     mockDownload.mockResolvedValue([newContent]);
 
-    // readFileSync throws EISDIR, localMd5 becomes empty, falls through to download.
-    // writeFile also throws EISDIR since cachePath is a directory,
-    // so the function propagates the error (expected for truly broken cache entries).
-    await expect(
-      downloadAsset(fakeApp, "model/doc/image.png", cacheDir)
-    ).rejects.toThrow();
-    expect(mockDownload).toHaveBeenCalledOnce();
+    try {
+      const result = await downloadAsset(fakeApp, "model/doc/image.png", cacheDir);
+      expect(result).toBe(true);
+      expect(mockDownload).toHaveBeenCalledOnce();
+    } finally {
+      // Restore permissions for cleanup
+      chmodSync(cachedPath, 0o644);
+    }
   });
 
   it("should not create additional metadata files in cache directory", async () => {

--- a/packages/core/src/__tests__/downloadAsset.test.ts
+++ b/packages/core/src/__tests__/downloadAsset.test.ts
@@ -90,6 +90,22 @@ describe("downloadAsset (md5 cache verification)", () => {
     expect(cached).toEqual(newContent);
   });
 
+  it("should reuse cached file when getMetadata fails", async () => {
+    const content = Buffer.from("cached-content");
+    const cachedPath = path.join(cacheDir, "model/doc/image.png");
+    mkdirSync(path.dirname(cachedPath), { recursive: true });
+    writeFileSync(cachedPath, content);
+
+    mockGetMetadata.mockRejectedValue(new Error("Network error"));
+
+    const result = await downloadAsset(fakeApp, "model/doc/image.png", cacheDir);
+
+    expect(result).toBe(false);
+    expect(mockDownload).not.toHaveBeenCalled();
+    // Cached file should remain unchanged
+    expect(readFileSync(cachedPath)).toEqual(content);
+  });
+
   it("should not create additional metadata files in cache directory", async () => {
     const content = Buffer.from("file-content");
     mockDownload.mockResolvedValue([content]);

--- a/packages/core/src/__tests__/downloadAsset.test.ts
+++ b/packages/core/src/__tests__/downloadAsset.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, readdirSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { downloadAsset } from "../assets.js";
+
+// Mock firebase-admin/storage
+const mockDownload = vi.fn();
+const mockGetMetadata = vi.fn();
+const mockFile = vi.fn(() => ({
+  download: mockDownload,
+  getMetadata: mockGetMetadata,
+}));
+const mockBucket = vi.fn(() => ({ file: mockFile }));
+
+vi.mock("firebase-admin/storage", () => ({
+  getStorage: () => ({ bucket: mockBucket }),
+}));
+
+const fakeApp = {} as import("firebase-admin/app").App;
+
+function md5Base64(content: Buffer): string {
+  return createHash("md5").update(content).digest("base64");
+}
+
+describe("downloadAsset (md5 cache verification)", () => {
+  let tmpDir: string;
+  let cacheDir: string;
+
+  beforeEach(() => {
+    tmpDir = path.join(
+      os.tmpdir(),
+      `contedra-md5-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    cacheDir = path.join(tmpDir, "cache");
+    mkdirSync(cacheDir, { recursive: true });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (tmpDir && existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should download files not in cache", async () => {
+    const content = Buffer.from("new-file-content");
+    mockDownload.mockResolvedValue([content]);
+
+    const result = await downloadAsset(fakeApp, "model/doc/image.png", cacheDir);
+
+    expect(result).toBe(true);
+    expect(mockDownload).toHaveBeenCalledOnce();
+    const cached = readFileSync(path.join(cacheDir, "model/doc/image.png"));
+    expect(cached).toEqual(content);
+  });
+
+  it("should skip re-download when cached file md5 matches remote", async () => {
+    const content = Buffer.from("cached-content");
+    const cachedPath = path.join(cacheDir, "model/doc/image.png");
+    mkdirSync(path.dirname(cachedPath), { recursive: true });
+    writeFileSync(cachedPath, content);
+
+    mockGetMetadata.mockResolvedValue([{ md5Hash: md5Base64(content) }]);
+
+    const result = await downloadAsset(fakeApp, "model/doc/image.png", cacheDir);
+
+    expect(result).toBe(false);
+    expect(mockGetMetadata).toHaveBeenCalledOnce();
+    expect(mockDownload).not.toHaveBeenCalled();
+  });
+
+  it("should re-download when cached file md5 differs from remote", async () => {
+    const oldContent = Buffer.from("old-content");
+    const newContent = Buffer.from("new-content");
+    const cachedPath = path.join(cacheDir, "model/doc/image.png");
+    mkdirSync(path.dirname(cachedPath), { recursive: true });
+    writeFileSync(cachedPath, oldContent);
+
+    // Remote has a different md5
+    mockGetMetadata.mockResolvedValue([{ md5Hash: md5Base64(newContent) }]);
+    mockDownload.mockResolvedValue([newContent]);
+
+    const result = await downloadAsset(fakeApp, "model/doc/image.png", cacheDir);
+
+    expect(result).toBe(true);
+    expect(mockDownload).toHaveBeenCalledOnce();
+    const cached = readFileSync(cachedPath);
+    expect(cached).toEqual(newContent);
+  });
+
+  it("should not create additional metadata files in cache directory", async () => {
+    const content = Buffer.from("file-content");
+    mockDownload.mockResolvedValue([content]);
+
+    await downloadAsset(fakeApp, "model/doc/image.png", cacheDir);
+
+    const dir = path.join(cacheDir, "model/doc");
+    const files = readdirSync(dir);
+    expect(files).toEqual(["image.png"]);
+  });
+});

--- a/packages/core/src/assets.ts
+++ b/packages/core/src/assets.ts
@@ -165,7 +165,10 @@ export async function downloadAsset(
     const localMd5 = createHash("md5").update(readFileSync(cachePath)).digest("base64");
     try {
       const [metadata] = await file.getMetadata();
-      if (metadata.md5Hash && localMd5 === metadata.md5Hash) {
+      if (!metadata.md5Hash) {
+        return false;
+      }
+      if (localMd5 === metadata.md5Hash) {
         return false;
       }
     } catch {

--- a/packages/core/src/assets.ts
+++ b/packages/core/src/assets.ts
@@ -162,18 +162,26 @@ export async function downloadAsset(
   const file = bucket.file(storagePath);
 
   if (existsSync(cachePath)) {
-    const localMd5 = createHash("md5").update(readFileSync(cachePath)).digest("base64");
+    let localMd5: string;
     try {
-      const [metadata] = await file.getMetadata();
-      if (!metadata.md5Hash) {
-        return false;
-      }
-      if (localMd5 === metadata.md5Hash) {
-        return false;
-      }
+      localMd5 = createHash("md5")
+        .update(readFileSync(cachePath))
+        .digest("base64");
     } catch {
-      // If metadata fetch fails, reuse cached file rather than failing the build
-      return false;
+      // Corrupt or unreadable cache entry: fall through to re-download
+      localMd5 = "";
+    }
+
+    if (localMd5) {
+      try {
+        const [metadata] = await file.getMetadata();
+        if (!metadata.md5Hash || localMd5 === metadata.md5Hash) {
+          return false;
+        }
+      } catch {
+        // If metadata fetch fails, reuse cached file rather than failing the build
+        return false;
+      }
     }
   }
 

--- a/packages/core/src/assets.ts
+++ b/packages/core/src/assets.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, copyFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, copyFileSync, readFileSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { App } from "firebase-admin/app";
@@ -156,16 +157,20 @@ export async function downloadAsset(
     throw new Error(`Asset path escapes cache directory: ${assetPath}`);
   }
 
+  const storagePath = `assets/${safePath}`;
+  const bucket = getStorage(app).bucket();
+  const file = bucket.file(storagePath);
+
   if (existsSync(cachePath)) {
-    return false;
+    const localMd5 = createHash("md5").update(readFileSync(cachePath)).digest("base64");
+    const [metadata] = await file.getMetadata();
+    if (localMd5 === metadata.md5Hash) {
+      return false;
+    }
   }
 
   const dir = path.dirname(cachePath);
   mkdirSync(dir, { recursive: true });
-
-  const storagePath = `assets/${safePath}`;
-  const bucket = getStorage(app).bucket();
-  const file = bucket.file(storagePath);
 
   const [contents] = await file.download();
   await writeFile(cachePath, contents);

--- a/packages/core/src/assets.ts
+++ b/packages/core/src/assets.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, copyFileSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, copyFileSync, readFileSync, unlinkSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { App } from "firebase-admin/app";
@@ -168,7 +168,8 @@ export async function downloadAsset(
         .update(readFileSync(cachePath))
         .digest("base64");
     } catch {
-      // Corrupt or unreadable cache entry: fall through to re-download
+      // Corrupt or unreadable cache entry: remove it and fall through to re-download
+      try { unlinkSync(cachePath); } catch { /* ignore cleanup errors */ }
       localMd5 = "";
     }
 

--- a/packages/core/src/assets.ts
+++ b/packages/core/src/assets.ts
@@ -163,8 +163,13 @@ export async function downloadAsset(
 
   if (existsSync(cachePath)) {
     const localMd5 = createHash("md5").update(readFileSync(cachePath)).digest("base64");
-    const [metadata] = await file.getMetadata();
-    if (localMd5 === metadata.md5Hash) {
+    try {
+      const [metadata] = await file.getMetadata();
+      if (metadata.md5Hash && localMd5 === metadata.md5Hash) {
+        return false;
+      }
+    } catch {
+      // If metadata fetch fails, reuse cached file rather than failing the build
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- Verify cached asset integrity by comparing local md5 hash against Firebase Storage `metadata.md5Hash` before skipping download
- Stale cached files are now automatically re-downloaded when the remote file changes
- No sidecar metadata files are created — md5 is computed on-the-fly from the cached file

## Changes
- `packages/core/src/assets.ts`: Updated `downloadAsset` to compute local md5 (base64) and compare with remote metadata before returning cached result
- `packages/core/src/__tests__/downloadAsset.test.ts`: Added 4 unit tests covering all acceptance criteria

## Test plan
- [x] Stale cached files are re-downloaded when remote md5 differs (mocked)
- [x] Unchanged cached files are skipped without re-download (mocked)
- [x] Files not in cache are downloaded as before
- [x] No additional metadata files are created in the cache directory
- [x] All existing tests pass (`pnpm build`, `pnpm lint`, unit tests)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Asset caching now uses remote MD5 validation: matching hashes skip downloads, mismatches overwrite cache, missing remote MD5 or metadata errors preserve existing cache. Storage resolution happens earlier in the retrieval flow.

* **Tests**
  * Added tests covering MD5-based cache behavior: initial download, skip-if-unchanged, overwrite-on-mismatch, missing-metadata, metadata errors, unreadable/corrupt cache handling, and ensuring no extra files are created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->