### PR TITLE
[AI] closes #33 feat(core): add asset dataType (schema 1.1.0)

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -61,7 +61,7 @@ Converts Firestore document data to proper JS types (Timestamps to Dates, etc.).
 
 ## Types
 
-contedra's content model definition format. The TypeScript interfaces below and the bundled JSON Schemas describe the same shape: a model is a list of typed properties (`dataType`-discriminated — `string` with a UI hint, `datetime`, `relatedOne`, `relatedMany`) intended for headless-CMS-style backends.
+contedra's content model definition format. The TypeScript interfaces below and the bundled JSON Schemas describe the same shape: a model is a list of typed properties (`dataType`-discriminated — `string` with a UI hint, `datetime`, `relatedOne`, `relatedMany`, `asset`) intended for headless-CMS-style backends.
 
 ```typescript
 interface ModelDefinition {
@@ -80,10 +80,12 @@ type ModelProperty =
   | StringProperty
   | DatetimeProperty
   | RelatedOneProperty
-  | RelatedManyProperty;
+  | RelatedManyProperty
+  | AssetProperty;
 
 type FieldElement = "input" | "textarea" | "markdown" | "select";
 type SearchPriority = "high" | "normal" | "low" | "none";
+type MediaType = "image"; // MVP — minor versions will add `video` / `audio` / `file`
 
 interface StringProperty {
   propertyName: string;
@@ -121,6 +123,15 @@ interface RelatedManyProperty {
   defaultValue?: string;
 }
 
+interface AssetProperty {
+  propertyName: string;
+  dataType: "asset";
+  mediaType: MediaType; // required, MVP: "image" only
+  require?: boolean;
+  // No `defaultValue`: an asset URI is contentId-scoped and cannot be
+  // hard-coded in the model definition.
+}
+
 interface FirebaseConfig {
   projectId: string;
   credential?: string; // Path to service account JSON
@@ -135,38 +146,83 @@ interface FirebaseConfig {
 | `"datetime"` | `propertyName`, `dataType` | `require`, `defaultValue`, `onUpdate` |
 | `"relatedOne"` | `propertyName`, `dataType`, `relatedModel` (ModelId) | `require`, `defaultValue` |
 | `"relatedMany"` | `propertyName`, `dataType`, `relatedModel` (ModelId) | `require`, `defaultValue` |
+| `"asset"` | `propertyName`, `dataType`, `mediaType` (MediaType) | `require` |
 
 Each property variant is `additionalProperties: false` in the JSON Schema so accidental keys are caught at validation time.
+
+### `asset` dataType — references to Firebase Storage objects
+
+An `asset` property holds a logical reference to a Firebase Storage object, parallel to how `relatedOne` / `relatedMany` reference documents in another collection. The persisted value is an `asset://` URI:
+
+```text
+asset://{modelName}/{contentId}/{fileId}
+```
+
+Example value: `asset://blog/abc123/cover.jpg`. The URI is logical, not physical — bucket name or storage path can change without rewriting the stored value; consumer-side resolvers (e.g. `resolveAssetUriToUrl`, `parseAssetUri`) do the lookup.
+
+Example model snippet:
+
+```json
+{
+  "id": "blog",
+  "modelName": "blog",
+  "properties": [
+    { "propertyName": "title", "dataType": "string", "fieldType": { "element": "input" }, "require": true },
+    { "propertyName": "cover", "dataType": "asset", "mediaType": "image", "require": true },
+    { "propertyName": "thumbnail", "dataType": "asset", "mediaType": "image" }
+  ]
+}
+```
+
+#### `mediaType` is a UI-branch enum, not a MIME type
+
+`mediaType` is **required** on every asset property and switches the editor / display UI (e.g. an image picker + preview vs. a video player). It is intentionally a coarse category, not a MIME type — keeping it small is what makes the picker UI tractable in a CMS surface.
+
+The MVP enum has a single value, `"image"`. Future minor versions of the schema will extend the enum with values like `"video"`, `"audio"`, and `"file"` as the corresponding pickers ship; consumers should treat unknown values as a hard validation error rather than silently downgrading.
+
+#### Why `defaultValue` is intentionally absent
+
+`asset` properties do not carry a `defaultValue`. An `asset://` URI is content-scoped (the `contentId` segment changes per document), so there is no useful value to hard-code in the model definition. Validators reject any `defaultValue` key on an asset property via `additionalProperties: false`.
 
 ## JSON Schemas
 
 The package ships JSON Schemas (Draft 2020-12) for validating model files in editors and CI. Each release of the schemas lives under a semver directory; the current schema version is exported as `SCHEMA_VERSION` from `@contedra/core`:
 
 ```text
-@contedra/core/schemas/1.0.0/model-definition.schema.json   # single ModelDefinition (Easy format)
-@contedra/core/schemas/1.0.0/model-manifest.schema.json     # ModelManifest (multi-model format)
+@contedra/core/schemas/1.1.0/model-definition.schema.json   # single ModelDefinition (Easy format)
+@contedra/core/schemas/1.1.0/model-manifest.schema.json     # ModelManifest (multi-model format)
 ```
+
+Older schema versions are kept alongside (`schemas/1.0.0/...`) so files pinned to an earlier `$schema` URL keep validating; the `@contedra/core/valibot` subpath always resolves to the current `SCHEMA_VERSION`.
 
 They are exposed through both `package.json` `exports` (Node-side `import`) and the npm tarball. **jsdelivr** automatically serves any file inside an npm package, so no separate hosting is needed.
 
 `model-manifest.schema.json` keeps its `models[]` shape in sync with `model-definition.schema.json` by referencing it through a top-level `$ref` (the same versioned jsdelivr URL pattern as `$id`), so the `ModelDefinition` shape lives in exactly one place.
+
+### Schema 1.1.0 — what changed
+
+`1.1.0` is purely additive over `1.0.0`:
+
+- New `$defs.MediaType` (enum, MVP value `"image"`).
+- New `$defs.AssetProperty` and a fifth `Property.oneOf` branch for `dataType: "asset"`.
+- Existing dataTypes (`string`, `datetime`, `relatedOne`, `relatedMany`) and their fields are unchanged. Files written against `1.0.0` continue to validate against `1.1.0`.
 
 ### URL convention — schema version pinned, package version free
 
 Each schema file's `$id` is a jsdelivr URL whose path carries the **schema** version (not the npm package version). jsdelivr resolves `@contedra/core` to whatever release is current, and as long as `@contedra/core` keeps shipping `schemas/<SCHEMA_VERSION>/...`, the URL stays stable forever:
 
 ```text
-https://cdn.jsdelivr.net/npm/@contedra/core/schemas/1.0.0/model-manifest.schema.json
+https://cdn.jsdelivr.net/npm/@contedra/core/schemas/1.1.0/model-manifest.schema.json
 ```
 
-A breaking schema change bumps `SCHEMA_VERSION` and ships under a fresh URL (`schemas/2.0.0/...`); existing files keep validating against the old URL.
+A breaking schema change bumps `SCHEMA_VERSION` and ships under a fresh URL (`schemas/2.0.0/...`); existing files keep validating against the old URL. Additive changes (e.g. the `1.0.0` → `1.1.0` AssetProperty addition) ship under a new minor segment so consumers can opt in by changing the URL.
 
 ### Reference a schema from your model file
 
 ```jsonc
 // my-models.json
 {
-  "$schema": "https://cdn.jsdelivr.net/npm/@contedra/core/schemas/1.0.0/model-manifest.schema.json",
+  "$schema": "https://cdn.jsdelivr.net/npm/@contedra/core/schemas/1.1.0/model-manifest.schema.json",
   "models": [
     { "id": "...", "modelName": "blog", "properties": [/* ... */] }
   ]

--- a/packages/core/generated/1.1.0/index.ts
+++ b/packages/core/generated/1.1.0/index.ts
@@ -1,0 +1,6 @@
+// Bundle entry point for `@contedra/core/valibot`. Re-exports the
+// auto-generated valibot schemas so consumers can import both
+// `ModelDefinitionSchema` and `ModelManifestSchema` from one subpath.
+
+export * from "./model-definition.valibot.js";
+export * from "./model-manifest.valibot.js";

--- a/packages/core/generated/1.1.0/model-definition.valibot.ts
+++ b/packages/core/generated/1.1.0/model-definition.valibot.ts
@@ -1,0 +1,72 @@
+// AUTO-GENERATED FROM model-definition.schema.json — DO NOT EDIT
+// Regenerate with: pnpm -F @contedra/core generate:valibot
+
+import {
+  array,
+  boolean,
+  literal,
+  maxLength,
+  minLength,
+  nonEmpty,
+  number,
+  optional,
+  picklist,
+  pipe,
+  regex,
+  strictObject,
+  string,
+  variant,
+} from "valibot";
+
+export const ModelIdSchema = pipe(string(), nonEmpty(), maxLength(128), regex(/^[a-zA-Z0-9_-]+$/));
+export const ModelNameSchema = pipe(string(), minLength(3), maxLength(64), regex(/^[a-z][a-z0-9_]*$/));
+export const PropertyNameSchema = pipe(string(), nonEmpty());
+export const SearchPrioritySchema = picklist(["high", "normal", "low", "none"]);
+export const FieldElementSchema = picklist(["input", "textarea", "markdown", "select"]);
+export const MediaTypeSchema = picklist(["image"]);
+export const StringPropertySchema = strictObject({
+  propertyName: PropertyNameSchema,
+  dataType: literal("string"),
+  fieldType: strictObject({
+  element: FieldElementSchema,
+}),
+  require: optional(boolean()),
+  min: optional(number()),
+  max: optional(number()),
+  regex: optional(string()),
+  defaultValue: optional(string()),
+  searchPriority: optional(SearchPrioritySchema),
+});
+export const DatetimePropertySchema = strictObject({
+  propertyName: PropertyNameSchema,
+  dataType: literal("datetime"),
+  require: optional(boolean()),
+  defaultValue: optional(string()),
+  onUpdate: optional(string()),
+});
+export const RelatedOnePropertySchema = strictObject({
+  propertyName: PropertyNameSchema,
+  dataType: literal("relatedOne"),
+  relatedModel: ModelIdSchema,
+  require: optional(boolean()),
+  defaultValue: optional(string()),
+});
+export const RelatedManyPropertySchema = strictObject({
+  propertyName: PropertyNameSchema,
+  dataType: literal("relatedMany"),
+  relatedModel: ModelIdSchema,
+  require: optional(boolean()),
+  defaultValue: optional(string()),
+});
+export const AssetPropertySchema = strictObject({
+  propertyName: PropertyNameSchema,
+  dataType: literal("asset"),
+  mediaType: MediaTypeSchema,
+  require: optional(boolean()),
+});
+export const ModelPropertySchema = variant("dataType", [StringPropertySchema, DatetimePropertySchema, RelatedOnePropertySchema, RelatedManyPropertySchema, AssetPropertySchema]);
+export const ModelDefinitionSchema = strictObject({
+  id: ModelIdSchema,
+  modelName: ModelNameSchema,
+  properties: array(ModelPropertySchema),
+});

--- a/packages/core/generated/1.1.0/model-manifest.valibot.ts
+++ b/packages/core/generated/1.1.0/model-manifest.valibot.ts
@@ -1,0 +1,15 @@
+// AUTO-GENERATED FROM model-manifest.schema.json — DO NOT EDIT
+// Regenerate with: pnpm -F @contedra/core generate:valibot
+
+import {
+  array,
+  looseObject,
+} from "valibot";
+
+import {
+  ModelDefinitionSchema,
+} from "./model-definition.valibot.js";
+
+export const ModelManifestSchema = looseObject({
+  models: array(ModelDefinitionSchema),
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,11 +11,13 @@
       "import": "./dist/src/index.js"
     },
     "./valibot": {
-      "types": "./dist/generated/1.0.0/index.d.ts",
-      "import": "./dist/generated/1.0.0/index.js"
+      "types": "./dist/generated/1.1.0/index.d.ts",
+      "import": "./dist/generated/1.1.0/index.js"
     },
     "./schemas/1.0.0/model-definition.schema.json": "./schemas/1.0.0/model-definition.schema.json",
     "./schemas/1.0.0/model-manifest.schema.json": "./schemas/1.0.0/model-manifest.schema.json",
+    "./schemas/1.1.0/model-definition.schema.json": "./schemas/1.1.0/model-definition.schema.json",
+    "./schemas/1.1.0/model-manifest.schema.json": "./schemas/1.1.0/model-manifest.schema.json",
     "./schemas/*": "./schemas/*"
   },
   "files": [

--- a/packages/core/schemas/1.1.0/model-definition.schema.json
+++ b/packages/core/schemas/1.1.0/model-definition.schema.json
@@ -1,0 +1,145 @@
+{
+  "$id": "https://cdn.jsdelivr.net/npm/@contedra/core/schemas/1.1.0/model-definition.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ModelDefinition",
+  "description": "A single content model definition (the Easy format). Describes the document id, the logical model name, and a list of typed properties used to render forms and persist data in headless-CMS-style backends.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "modelName", "properties"],
+  "properties": {
+    "id": { "$ref": "#/$defs/ModelId" },
+    "modelName": { "$ref": "#/$defs/ModelName" },
+    "properties": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Property" }
+    }
+  },
+  "$defs": {
+    "ModelId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[a-zA-Z0-9_-]+$",
+      "description": "Stable document id (alphanumerics plus `-` and `_`, up to 128 chars)."
+    },
+    "ModelName": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 64,
+      "pattern": "^[a-z][a-z0-9_]*$",
+      "description": "Logical model name, also used as the storage collection name. Lowercase, must start with a letter, 3-64 chars."
+    },
+    "PropertyName": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Property field name. Must be a non-empty string."
+    },
+    "SearchPriority": {
+      "description": "Search-index weighting hint: 'high' | 'normal' | 'low' | 'none' ('none' opts the field out of search).",
+      "enum": ["high", "normal", "low", "none"]
+    },
+    "FieldElement": {
+      "description": "UI hint for how the string value should be edited: 'input' | 'textarea' | 'markdown' | 'select'.",
+      "enum": ["input", "textarea", "markdown", "select"]
+    },
+    "MediaType": {
+      "description": "Asset broad category, used to switch the editor / display UI. MVP supports `image` only; future minor versions will add `video` / `audio` / `file`. Not a MIME type.",
+      "enum": ["image"]
+    },
+    "Property": {
+      "description": "Discriminated union over `dataType`: a property is one of StringProperty | DatetimeProperty | RelatedOneProperty | RelatedManyProperty | AssetProperty.",
+      "oneOf": [
+        { "$ref": "#/$defs/StringProperty" },
+        { "$ref": "#/$defs/DatetimeProperty" },
+        { "$ref": "#/$defs/RelatedOneProperty" },
+        { "$ref": "#/$defs/RelatedManyProperty" },
+        { "$ref": "#/$defs/AssetProperty" }
+      ]
+    },
+    "StringProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["propertyName", "dataType", "fieldType"],
+      "properties": {
+        "propertyName": { "$ref": "#/$defs/PropertyName" },
+        "dataType": { "const": "string" },
+        "fieldType": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["element"],
+          "properties": {
+            "element": { "$ref": "#/$defs/FieldElement" }
+          }
+        },
+        "require": {
+          "type": "boolean",
+          "description": "Whether this field is required."
+        },
+        "min": { "type": "number" },
+        "max": { "type": "number" },
+        "regex": { "type": "string" },
+        "defaultValue": { "type": "string" },
+        "searchPriority": { "$ref": "#/$defs/SearchPriority" }
+      }
+    },
+    "DatetimeProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["propertyName", "dataType"],
+      "properties": {
+        "propertyName": { "$ref": "#/$defs/PropertyName" },
+        "dataType": { "const": "datetime" },
+        "require": {
+          "type": "boolean",
+          "description": "Whether this field is required."
+        },
+        "defaultValue": { "type": "string" },
+        "onUpdate": { "type": "string" }
+      }
+    },
+    "RelatedOneProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["propertyName", "dataType", "relatedModel"],
+      "properties": {
+        "propertyName": { "$ref": "#/$defs/PropertyName" },
+        "dataType": { "const": "relatedOne" },
+        "relatedModel": { "$ref": "#/$defs/ModelId" },
+        "require": {
+          "type": "boolean",
+          "description": "Whether this field is required."
+        },
+        "defaultValue": { "type": "string" }
+      }
+    },
+    "RelatedManyProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["propertyName", "dataType", "relatedModel"],
+      "properties": {
+        "propertyName": { "$ref": "#/$defs/PropertyName" },
+        "dataType": { "const": "relatedMany" },
+        "relatedModel": { "$ref": "#/$defs/ModelId" },
+        "require": {
+          "type": "boolean",
+          "description": "Whether this field is required."
+        },
+        "defaultValue": { "type": "string" }
+      }
+    },
+    "AssetProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["propertyName", "dataType", "mediaType"],
+      "properties": {
+        "propertyName": { "$ref": "#/$defs/PropertyName" },
+        "dataType": { "const": "asset" },
+        "mediaType": { "$ref": "#/$defs/MediaType" },
+        "require": {
+          "type": "boolean",
+          "description": "Whether this field is required."
+        }
+      }
+    }
+  }
+}

--- a/packages/core/schemas/1.1.0/model-manifest.schema.json
+++ b/packages/core/schemas/1.1.0/model-manifest.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://cdn.jsdelivr.net/npm/@contedra/core/schemas/1.1.0/model-manifest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ModelManifest",
+  "description": "Wrapper format that bundles multiple content model definitions in one file. Each entry under `models` references the `ModelDefinition` schema by `$ref` so the shape stays defined in exactly one place.",
+  "type": "object",
+  "required": ["models"],
+  "additionalProperties": true,
+  "properties": {
+    "models": {
+      "type": "array",
+      "items": {
+        "$ref": "https://cdn.jsdelivr.net/npm/@contedra/core/schemas/1.1.0/model-definition.schema.json"
+      }
+    }
+  }
+}

--- a/packages/core/src/__tests__/fixtures/asset_blog.json
+++ b/packages/core/src/__tests__/fixtures/asset_blog.json
@@ -1,0 +1,9 @@
+{
+  "id": "blog_with_assets",
+  "modelName": "blog_with_assets",
+  "properties": [
+    { "propertyName": "title", "dataType": "string", "fieldType": { "element": "input" }, "require": true },
+    { "propertyName": "cover", "dataType": "asset", "mediaType": "image", "require": true },
+    { "propertyName": "thumbnail", "dataType": "asset", "mediaType": "image" }
+  ]
+}

--- a/packages/core/src/__tests__/fixtures/invalid_asset_missing_media_type.json
+++ b/packages/core/src/__tests__/fixtures/invalid_asset_missing_media_type.json
@@ -1,0 +1,7 @@
+{
+  "id": "invalid",
+  "modelName": "invalid_asset",
+  "properties": [
+    { "propertyName": "cover", "dataType": "asset" }
+  ]
+}

--- a/packages/core/src/__tests__/fixtures/invalid_asset_unsupported_media_type.json
+++ b/packages/core/src/__tests__/fixtures/invalid_asset_unsupported_media_type.json
@@ -1,0 +1,7 @@
+{
+  "id": "invalid",
+  "modelName": "invalid_asset",
+  "properties": [
+    { "propertyName": "clip", "dataType": "asset", "mediaType": "video" }
+  ]
+}

--- a/packages/core/src/__tests__/fixtures/invalid_asset_with_default_value.json
+++ b/packages/core/src/__tests__/fixtures/invalid_asset_with_default_value.json
@@ -1,0 +1,12 @@
+{
+  "id": "invalid",
+  "modelName": "invalid_asset",
+  "properties": [
+    {
+      "propertyName": "cover",
+      "dataType": "asset",
+      "mediaType": "image",
+      "defaultValue": "asset://blog/abc/cover.jpg"
+    }
+  ]
+}

--- a/packages/core/src/__tests__/fixtures/manifest_with_asset.json
+++ b/packages/core/src/__tests__/fixtures/manifest_with_asset.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://cdn.jsdelivr.net/npm/@contedra/core/schemas/1.1.0/model-manifest.schema.json",
+  "models": [
+    {
+      "id": "article",
+      "modelName": "article",
+      "properties": [
+        { "propertyName": "title", "dataType": "string", "fieldType": { "element": "input" }, "require": true },
+        { "propertyName": "cover", "dataType": "asset", "mediaType": "image", "require": true }
+      ]
+    },
+    {
+      "id": "author",
+      "modelName": "author",
+      "properties": [
+        { "propertyName": "displayName", "dataType": "string", "fieldType": { "element": "input" }, "require": true },
+        { "propertyName": "avatar", "dataType": "asset", "mediaType": "image" }
+      ]
+    }
+  ]
+}

--- a/packages/core/src/__tests__/generated-valibot-1.0.0.test.ts
+++ b/packages/core/src/__tests__/generated-valibot-1.0.0.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { safeParse } from "valibot";
+import {
+  ModelDefinitionSchema,
+  ModelManifestSchema,
+} from "../../generated/1.0.0/index.js";
+
+const fixturesDir = resolve(import.meta.dirname, "fixtures");
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, "utf-8"));
+}
+
+// Regression coverage for `@contedra/core/generated/1.0.0` — the schema and
+// generated valibot module shipped before AssetProperty was introduced. We
+// keep these alive so old consumers that pin `generated/1.0.0/...` don't
+// silently break when 1.1.0 is released.
+
+describe("generated valibot 1.0.0 — ModelDefinitionSchema (regression)", () => {
+  it("accepts every model in the golden manifest", () => {
+    const manifest = readJson(
+      resolve(fixturesDir, "golden_full_example.json")
+    ) as { models: unknown[] };
+    expect(manifest.models.length).toBeGreaterThan(0);
+    for (const model of manifest.models) {
+      const result = safeParse(ModelDefinitionSchema, model);
+      expect(
+        result.success,
+        result.success ? undefined : JSON.stringify(result.issues, null, 2)
+      ).toBe(true);
+    }
+  });
+
+  it("accepts the single-model fixture", () => {
+    const data = readJson(resolve(fixturesDir, "blog_posts.json"));
+    expect(safeParse(ModelDefinitionSchema, data).success).toBe(true);
+  });
+
+  it("rejects an asset dataType (not part of 1.0.0)", () => {
+    const data = readJson(resolve(fixturesDir, "asset_blog.json"));
+    expect(safeParse(ModelDefinitionSchema, data).success).toBe(false);
+  });
+});
+
+describe("generated valibot 1.0.0 — ModelManifestSchema (regression)", () => {
+  it("accepts the multi-entry manifest fixture", () => {
+    const data = readJson(resolve(fixturesDir, "manifest_multi.json"));
+    expect(safeParse(ModelManifestSchema, data).success).toBe(true);
+  });
+
+  it("accepts the full-coverage golden manifest", () => {
+    const data = readJson(resolve(fixturesDir, "golden_full_example.json"));
+    expect(safeParse(ModelManifestSchema, data).success).toBe(true);
+  });
+
+  it("rejects a manifest carrying an asset property (1.0.0 has no AssetProperty)", () => {
+    const data = readJson(resolve(fixturesDir, "manifest_with_asset.json"));
+    expect(safeParse(ModelManifestSchema, data).success).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/generated-valibot.test.ts
+++ b/packages/core/src/__tests__/generated-valibot.test.ts
@@ -5,7 +5,7 @@ import { safeParse } from "valibot";
 import {
   ModelDefinitionSchema,
   ModelManifestSchema,
-} from "../../generated/1.0.0/index.js";
+} from "../../generated/1.1.0/index.js";
 
 const fixturesDir = resolve(import.meta.dirname, "fixtures");
 
@@ -120,5 +120,73 @@ describe("generated valibot — ModelManifestSchema", () => {
   it("rejects a bare ModelDefinition (not wrapped in `models`)", () => {
     const data = readJson(resolve(fixturesDir, "blog_posts.json"));
     expect(safeParse(ModelManifestSchema, data).success).toBe(false);
+  });
+
+  it("accepts a manifest containing asset properties", () => {
+    const data = readJson(resolve(fixturesDir, "manifest_with_asset.json"));
+    const result = safeParse(ModelManifestSchema, data);
+    expect(
+      result.success,
+      result.success ? undefined : JSON.stringify(result.issues, null, 2)
+    ).toBe(true);
+  });
+});
+
+describe("generated valibot — AssetProperty", () => {
+  it("accepts an asset property fixture with mediaType: image", () => {
+    const data = readJson(resolve(fixturesDir, "asset_blog.json"));
+    const result = safeParse(ModelDefinitionSchema, data);
+    expect(
+      result.success,
+      result.success ? undefined : JSON.stringify(result.issues, null, 2)
+    ).toBe(true);
+  });
+
+  it("rejects an asset property without mediaType", () => {
+    const data = readJson(
+      resolve(fixturesDir, "invalid_asset_missing_media_type.json")
+    );
+    expect(safeParse(ModelDefinitionSchema, data).success).toBe(false);
+  });
+
+  it("rejects an asset property with an unsupported mediaType value", () => {
+    const data = readJson(
+      resolve(fixturesDir, "invalid_asset_unsupported_media_type.json")
+    );
+    expect(safeParse(ModelDefinitionSchema, data).success).toBe(false);
+  });
+
+  it("rejects an asset property carrying a defaultValue (additionalProperties: false)", () => {
+    const data = readJson(
+      resolve(fixturesDir, "invalid_asset_with_default_value.json")
+    );
+    expect(safeParse(ModelDefinitionSchema, data).success).toBe(false);
+  });
+
+  it("accepts an optional asset property without `require`", () => {
+    const data = {
+      id: "blog",
+      modelName: "blog",
+      properties: [
+        { propertyName: "thumbnail", dataType: "asset", mediaType: "image" },
+      ],
+    };
+    expect(safeParse(ModelDefinitionSchema, data).success).toBe(true);
+  });
+
+  it("rejects an asset property with an unknown extra key", () => {
+    const data = {
+      id: "blog",
+      modelName: "blog",
+      properties: [
+        {
+          propertyName: "cover",
+          dataType: "asset",
+          mediaType: "image",
+          extra: "nope",
+        },
+      ],
+    };
+    expect(safeParse(ModelDefinitionSchema, data).success).toBe(false);
   });
 });

--- a/packages/core/src/__tests__/schemas.test.ts
+++ b/packages/core/src/__tests__/schemas.test.ts
@@ -249,4 +249,35 @@ describe("JSON Schemas — ajv validation", () => {
     );
     expect(validateManifest(data)).toBe(true);
   });
+
+  it("accepts an asset property fixture with mediaType: image", () => {
+    const data = readJson(resolve(fixturesDir, "asset_blog.json"));
+    expect(validateDefinition(data)).toBe(true);
+  });
+
+  it("accepts a manifest carrying asset properties", () => {
+    const data = readJson(resolve(fixturesDir, "manifest_with_asset.json"));
+    expect(validateManifest(data)).toBe(true);
+  });
+
+  it("rejects an asset property without mediaType", () => {
+    const data = readJson(
+      resolve(fixturesDir, "invalid_asset_missing_media_type.json")
+    );
+    expect(validateDefinition(data)).toBe(false);
+  });
+
+  it("rejects an asset property with an unsupported mediaType value", () => {
+    const data = readJson(
+      resolve(fixturesDir, "invalid_asset_unsupported_media_type.json")
+    );
+    expect(validateDefinition(data)).toBe(false);
+  });
+
+  it("rejects an asset property carrying a defaultValue (additionalProperties: false)", () => {
+    const data = readJson(
+      resolve(fixturesDir, "invalid_asset_with_default_value.json")
+    );
+    expect(validateDefinition(data)).toBe(false);
+  });
 });

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -6,4 +6,4 @@
  * Bump alongside breaking changes to the schema; the value MUST equal
  * the directory name that ships the schemas in this release.
  */
-export const SCHEMA_VERSION = "1.0.0";
+export const SCHEMA_VERSION = "1.1.0";

--- a/scripts/generate-valibot.mjs
+++ b/scripts/generate-valibot.mjs
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..");
-const SCHEMA_VERSION = "1.0.0";
+const SCHEMA_VERSION = "1.1.0";
 const SCHEMAS_DIR = path.resolve(
   REPO_ROOT,
   `packages/core/schemas/${SCHEMA_VERSION}`
@@ -28,7 +28,7 @@ const OUT_DIR = path.resolve(
 // Maps external schema $id URLs to the symbol they should be imported as,
 // plus the relative module they live in.
 const EXTERNAL_REFS = {
-  "https://cdn.jsdelivr.net/npm/@contedra/core/schemas/1.0.0/model-definition.schema.json":
+  [`https://cdn.jsdelivr.net/npm/@contedra/core/schemas/${SCHEMA_VERSION}/model-definition.schema.json`]:
     {
       symbol: "ModelDefinitionSchema",
       module: "./model-definition.valibot.js",
@@ -50,11 +50,13 @@ const TARGETS = [
       PropertyName: "PropertyNameSchema",
       SearchPriority: "SearchPrioritySchema",
       FieldElement: "FieldElementSchema",
+      MediaType: "MediaTypeSchema",
       Property: "ModelPropertySchema",
       StringProperty: "StringPropertySchema",
       DatetimeProperty: "DatetimePropertySchema",
       RelatedOneProperty: "RelatedOnePropertySchema",
       RelatedManyProperty: "RelatedManyPropertySchema",
+      AssetProperty: "AssetPropertySchema",
     },
   },
   {


### PR DESCRIPTION
## Summary
- Introduces `dataType: "asset"` as the fifth `Property` variant in `@contedra/core`, holding a logical reference (`asset://{modelName}/{contentId}/{fileId}`) to a Firebase Storage object.
- Ships schema **1.1.0** (`MediaType` + `AssetProperty` $defs, `Property.oneOf` extended); 1.0.0 schemas are kept alongside for pinned consumers.
- Regenerates `@contedra/core/valibot` from the 1.1.0 schemas — `MediaTypeSchema = picklist(["image"])`, `AssetPropertySchema = strictObject(...)`, `ModelPropertySchema` variant extended. Re-targets `exports."./valibot"` at `generated/1.1.0` and adds `exports."./schemas/1.1.0/*"` entries.
- Three-party agreed spec (corp-website / CTO room conteditor / toolkit) — `mediaType` is a UI-branch enum (MVP: `"image"` only), required on every asset property; `defaultValue` is intentionally absent (asset URI is `contentId`-scoped).

## Schema 1.1.0 — what changed
Purely additive over 1.0.0. Files written against `1.0.0` keep validating against `1.1.0`; existing dataType behaviour is unchanged.

```json
"MediaType": { "enum": ["image"] },
"AssetProperty": {
  "type": "object",
  "additionalProperties": false,
  "required": ["propertyName", "dataType", "mediaType"],
  "properties": {
    "propertyName": { "$ref": "#/$defs/PropertyName" },
    "dataType":     { "const": "asset" },
    "mediaType":    { "$ref": "#/$defs/MediaType" },
    "require":      { "type": "boolean" }
  }
}
```

## Version migration path
- **0.3.2** (current `main`, PR #32) shipped `ModelManifestSchema` on `@contedra/core/valibot`.
- **0.4.0** (this PR, on next release) ships `AssetPropertySchema` + schema 1.1.0.
- **No `package.json.version` bump in this PR** per CLAUDE.md release rule. Next release: `./scripts/release.sh minor` from `main` will bump all packages 0.3.2 → **0.4.0** in one go (core / astro-loader-firestore / md-importer).

## Verification
- `pnpm lint` — only pre-existing warnings (`writeFileSync` / `beforeEach` unused imports), nothing introduced by this PR.
- `pnpm build` — `core`, `astro-loader-firestore`, `md-importer` all build clean. `demo` build fails locally on Firestore credential lookup — pre-existing local-only issue, unrelated to this change.
- `pnpm test` — all packages green via `firebase emulators:exec --only storage`:
  - `@contedra/core`: **125 tests passed** (9 files), incl. emulator integration suite.
  - `@contedra/astro-loader-firestore`: 8 tests passed.
  - `@contedra/md-importer`: 32 tests passed.
- New fixtures + tests cover the agreed accept/reject cases for AssetProperty:
  - accept: `asset_blog.json`, `manifest_with_asset.json`, optional-`require` shape.
  - reject: `mediaType` missing, `mediaType: "video"` (unsupported), `defaultValue` present, unknown extra key.
- Regression: `generated-valibot-1.0.0.test.ts` ensures `generated/1.0.0` still accepts existing fixtures and rejects asset-bearing fixtures (no leakage from 1.1.0).
- `schemas.test.ts` adds ajv coverage for the same accept/reject cases.

## Test plan
- [ ] CI green on this PR (lint / build / test, including the storage-emulator test run).
- [ ] After merge, leader runs `./scripts/release.sh minor` from `main` to ship `@contedra/core@0.4.0` (and the parallel packages).
- [ ] Downstream conteditor (CTO room) mirrors the same `AssetPropertySchema` locally for the picker UI; spec parity confirmed at the 30% checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asset property support to content models, enabling you to define image assets within your content structure with required media type specifications.

* **Documentation**
  * Schema documentation updated to reflect new asset property type and schema version 1.1.0.
  * Asset properties require a media type and do not support default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->