### PR TITLE
[AI] closes #35 feat: add asset dataType support to md-importer & astro-loader-firestore

### DIFF
--- a/packages/astro-loader-firestore/README.md
+++ b/packages/astro-loader-firestore/README.md
@@ -160,6 +160,18 @@ assets: { mode: "url" }
 | `datetime` | `z.coerce.date()` | Firestore Timestamp converted to Date |
 | `relatedOne` | `z.string()` | Referenced document ID |
 | `relatedMany` | `z.array(z.string())` | Array of referenced document IDs |
+| `asset` | `z.string()` | Resolved asset URL string (see [Asset Resolution](#asset-resolution)). MVP supports `mediaType: "image"`; future schema versions will add `video` / `audio` / `file`. |
+
+## `asset` dataType vs. legacy `string` + `--image-fields`
+
+Two ways exist to carry image references through the pipeline. Both end up resolved by the loader transparently — `getCollection().data.cover` is a plain URL string in templates regardless of which path was used.
+
+| Source | Model declaration | md-importer side | Loader side |
+|--------|-------------------|------------------|-------------|
+| **Recommended** | `dataType: "asset"`, `mediaType: "image"` | Frontmatter value is auto-uploaded — no `--image-fields` needed | `asset://` URI in Firestore is auto-resolved per `assets` config |
+| Legacy / backward-compat | `dataType: "string"` | Pass `--image-fields cover,…` to upload | Same — the loader resolves any `asset://` URI it encounters in string values |
+
+The loader does not branch on `dataType` for asset resolution — it walks every string value in the document and replaces `asset://` URIs. So both columns behave identically downstream once the data lands in Firestore. The only practical difference is whether md-importer auto-uploads (asset dataType) or requires opt-in (`--image-fields`).
 
 ## Resolving References
 

--- a/packages/astro-loader-firestore/src/__tests__/loader.test.ts
+++ b/packages/astro-loader-firestore/src/__tests__/loader.test.ts
@@ -62,7 +62,9 @@ vi.mock("node:fs", () => ({
 import { contedraLoader } from "../loader.js";
 import {
   loadModel,
+  resolveModel,
   detectBodyField,
+  buildSchema,
   initFirestore,
   fetchDocuments,
   transformDocumentData,
@@ -338,6 +340,93 @@ describe("contedraLoader — modelName forwarding", () => {
       "./models/blog_posts.json",
       undefined
     );
+  });
+});
+
+describe("contedraLoader with asset dataType fields", () => {
+  const assetModel = {
+    id: "blog_with_asset",
+    modelName: "blog_with_asset",
+    properties: [
+      {
+        propertyName: "title",
+        dataType: "string" as const,
+        fieldType: { element: "input" as const },
+      },
+      {
+        propertyName: "cover",
+        dataType: "asset" as const,
+        mediaType: "image" as const,
+        require: true,
+      },
+      {
+        propertyName: "content",
+        dataType: "string" as const,
+        fieldType: { element: "markdown" as const },
+      },
+    ],
+  };
+
+  const baseConfig: ContedraLoaderConfig = {
+    modelFile: "./models/blog_with_asset.json",
+    firebaseConfig: {
+      projectId: "test-project",
+      storageBucket: "test-project.firebasestorage.app",
+    },
+    assets: { mode: "url" },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(loadModel).mockResolvedValue(assetModel);
+    vi.mocked(detectBodyField).mockReturnValue("content");
+    vi.mocked(initFirestore).mockReturnValue({} as any);
+    vi.mocked(resolveAssetUriToUrl).mockImplementation(
+      (uri, bucket) =>
+        `https://firebasestorage.googleapis.com/v0/b/${bucket}/o/assets%2F${uri.replace("asset://", "").replace(/\//g, "%2F")}?alt=media`
+    );
+  });
+
+  it("resolves asset:// URIs in asset dataType fields (url mode)", async () => {
+    vi.mocked(fetchDocuments).mockResolvedValue([
+      {
+        id: "post-1",
+        data: {
+          title: "Hello",
+          cover: "asset://blog_with_asset/post-1/cover.png",
+          content: "# Body",
+        },
+      },
+    ]);
+    vi.mocked(transformDocumentData).mockReturnValue({
+      data: {
+        title: "Hello",
+        cover: "asset://blog_with_asset/post-1/cover.png",
+      },
+      body: "# Body",
+    });
+
+    const loader = contedraLoader(baseConfig);
+    const ctx = createMockContext();
+    await loader.load(ctx as any);
+
+    const setCall = ctx.store.set.mock.calls[0][0];
+    expect(setCall.data.cover).toContain("firebasestorage.googleapis.com");
+    expect(setCall.data.cover).not.toContain("asset://");
+  });
+
+  it("schema() forwards asset properties to buildSchema (asset → string handled by core)", async () => {
+    vi.mocked(resolveModel).mockReturnValue(assetModel);
+    vi.mocked(detectBodyField).mockReturnValue("content");
+    const fakeSchema = { _kind: "zod-object" };
+    vi.mocked(buildSchema).mockReturnValue(fakeSchema as any);
+    const fs = await import("node:fs");
+    vi.mocked(fs.readFileSync).mockReturnValue("{}");
+
+    const loader = contedraLoader(baseConfig);
+    const schema = loader.schema!();
+    expect(buildSchema).toHaveBeenCalledWith(assetModel.properties, "content");
+    expect(schema).toBe(fakeSchema);
   });
 });
 

--- a/packages/core/src/__tests__/firestore.test.ts
+++ b/packages/core/src/__tests__/firestore.test.ts
@@ -12,6 +12,7 @@ const model: ModelDefinition = {
     { propertyName: "publishedAt", dataType: "datetime" },
     { propertyName: "category", dataType: "relatedOne", relatedModel: "categories" },
     { propertyName: "tags", dataType: "relatedMany", relatedModel: "tags" },
+    { propertyName: "cover", dataType: "asset", mediaType: "image" },
   ],
 };
 
@@ -95,5 +96,18 @@ describe("transformDocumentData", () => {
     expect(result.body).toBeUndefined();
     expect(result.data.content).toBe("# My Post");
     expect(result.data.title).toBe("Hello");
+  });
+
+  it("should pass through asset:// URI strings for asset fields", () => {
+    const result = transformDocumentData(
+      {
+        title: "Hello",
+        cover: "asset://blog_posts/post-1/cover.png",
+      },
+      model,
+      "content"
+    );
+
+    expect(result.data.cover).toBe("asset://blog_posts/post-1/cover.png");
   });
 });

--- a/packages/core/src/__tests__/schema.test.ts
+++ b/packages/core/src/__tests__/schema.test.ts
@@ -55,6 +55,33 @@ describe("dataTypeToZod", () => {
     const schema = dataTypeToZod(prop);
     expect(schema.parse(["tag-1", "tag-2"])).toEqual(["tag-1", "tag-2"]);
   });
+
+  it("should convert asset to z.string() (asset:// URI carried as string)", () => {
+    const prop: ModelProperty = {
+      propertyName: "cover",
+      dataType: "asset",
+      mediaType: "image",
+      require: true,
+    };
+    const schema = dataTypeToZod(prop);
+    expect(schema.parse("asset://blog/post-1/cover.png")).toBe(
+      "asset://blog/post-1/cover.png"
+    );
+    expect(() => schema.parse(undefined)).toThrow();
+  });
+
+  it("should make optional asset fields accept undefined", () => {
+    const prop: ModelProperty = {
+      propertyName: "thumbnail",
+      dataType: "asset",
+      mediaType: "image",
+    };
+    const schema = dataTypeToZod(prop);
+    expect(schema.parse(undefined)).toBeUndefined();
+    expect(schema.parse("asset://blog/post-1/thumb.png")).toBe(
+      "asset://blog/post-1/thumb.png"
+    );
+  });
 });
 
 describe("buildSchema", () => {

--- a/packages/core/src/firestore.ts
+++ b/packages/core/src/firestore.ts
@@ -86,6 +86,8 @@ function convertValue(
         });
       }
       return [];
+    case "asset":
+      return typeof value === "string" ? value : String(value);
     default:
       return value;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,7 +22,9 @@ export type {
   DatetimeProperty,
   RelatedOneProperty,
   RelatedManyProperty,
+  AssetProperty,
   FieldElement,
   SearchPriority,
+  MediaType,
   FirebaseConfig,
 } from "./types.js";

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -17,6 +17,9 @@ export function dataTypeToZod(property: ModelProperty): ZodTypeAny {
     case "relatedMany":
       schema = z.array(z.string());
       break;
+    case "asset":
+      schema = z.string();
+      break;
     default:
       schema = z.unknown();
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,6 +9,12 @@ export type FieldElement = "input" | "textarea" | "markdown" | "select";
 
 export type SearchPriority = "high" | "normal" | "low" | "none";
 
+/**
+ * Asset broad category. Matches MediaType in the JSON Schema 1.1.0 / valibot.
+ * MVP supports `image` only; future minor versions will add `video` / `audio` / `file`.
+ */
+export type MediaType = "image";
+
 export interface StringProperty {
   propertyName: string;
   dataType: "string";
@@ -45,11 +51,19 @@ export interface RelatedManyProperty {
   defaultValue?: string;
 }
 
+export interface AssetProperty {
+  propertyName: string;
+  dataType: "asset";
+  mediaType: MediaType;
+  require?: boolean;
+}
+
 export type ModelProperty =
   | StringProperty
   | DatetimeProperty
   | RelatedOneProperty
-  | RelatedManyProperty;
+  | RelatedManyProperty
+  | AssetProperty;
 
 export interface ModelDefinition {
   id: string;

--- a/packages/md-importer/README.md
+++ b/packages/md-importer/README.md
@@ -32,7 +32,7 @@ npx @contedra/md-importer \
 | `--storage-bucket <name>` | No* | Firebase Storage bucket name (e.g. `your-project.firebasestorage.app`) |
 | `--no-images` | No | Skip image extraction, upload, and URL replacement |
 | `--image-base-dir <path>` | No | Directory for resolving absolute image paths (e.g. `./public`) |
-| `--image-fields <fields>` | No | Comma-separated frontmatter field names containing image paths (e.g. `heroImage,cover`) |
+| `--image-fields <fields>` | No | Comma-separated frontmatter field names containing image paths (e.g. `heroImage,cover`). Only needed for `dataType: "string"` fields; `dataType: "asset"` fields are auto-recognized. |
 | `--field-mapping <json>` | No | JSON mapping frontmatter keys to model properties |
 
 ### Importing from a multi-model manifest file
@@ -125,6 +125,48 @@ Images referenced in Markdown (e.g., `![alt](./images/photo.png)`) are:
 4. Replaced in the markdown body with `asset://` URIs
 
 External URLs (`http://`, `https://`) and `asset://` URIs are skipped.
+
+## Frontmatter Image Fields
+
+Two paths are supported for converting frontmatter image paths into `asset://` URIs:
+
+### 1. `dataType: "asset"` (recommended, auto-recognized)
+
+If a model property is declared as `dataType: "asset"` with `mediaType: "image"`, the importer **automatically uploads** the value (a relative or absolute path) and rewrites the frontmatter field to an `asset://` URI. No `--image-fields` flag needed.
+
+```json
+// model.json
+{
+  "id": "blog_posts",
+  "modelName": "blog_posts",
+  "properties": [
+    { "propertyName": "title", "dataType": "string", "fieldType": { "element": "input" }, "require": true },
+    { "propertyName": "cover", "dataType": "asset", "mediaType": "image", "require": true },
+    { "propertyName": "thumbnail", "dataType": "asset", "mediaType": "image" }
+  ]
+}
+```
+
+```yaml
+# post.md frontmatter
+title: Hello
+cover: ./images/cover.png
+thumbnail: ./images/thumb.png
+```
+
+After import: `cover` and `thumbnail` are stored as `asset://blog_posts/{docId}/cover.png` and `asset://blog_posts/{docId}/thumb.png`. Values that are already `asset://`, `http://`, or `https://` URIs are passed through unchanged (idempotent re-import).
+
+> **MVP note:** only `mediaType: "image"` triggers upload today. Future schema versions will add `video` / `audio` / `file`; until then, those values are rejected by `@contedra/core` schema validation.
+
+### 2. `--image-fields` (legacy, for `dataType: "string"` fields)
+
+For models that store image paths in plain `string`-typed fields, pass `--image-fields` to opt-in field-by-field. This path remains available for backward compatibility.
+
+```bash
+npx @contedra/md-importer ... --image-fields heroImage,cover
+```
+
+The two paths can be combined; if a field is named in both an `asset` property and `--image-fields`, it is uploaded once.
 
 ## License
 

--- a/packages/md-importer/src/__tests__/fixtures/blog_posts_with_asset.json
+++ b/packages/md-importer/src/__tests__/fixtures/blog_posts_with_asset.json
@@ -1,0 +1,11 @@
+{
+  "id": "blog_posts_asset",
+  "modelName": "blog_posts_asset",
+  "properties": [
+    { "propertyName": "title", "dataType": "string", "fieldType": { "element": "input" }, "require": true },
+    { "propertyName": "cover", "dataType": "asset", "mediaType": "image", "require": true },
+    { "propertyName": "thumbnail", "dataType": "asset", "mediaType": "image" },
+    { "propertyName": "content", "dataType": "string", "fieldType": { "element": "markdown" } },
+    { "propertyName": "publishedAt", "dataType": "datetime" }
+  ]
+}

--- a/packages/md-importer/src/__tests__/images.test.ts
+++ b/packages/md-importer/src/__tests__/images.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest";
 import path from "node:path";
+import type { ModelDefinition } from "@contedra/core";
 import {
   extractImageRefs,
   assetStoragePath,
   assetUri,
   replaceImageRefs,
   defaultResolveImage,
+  resolveImageFieldNames,
 } from "../images.js";
 
 describe("extractImageRefs", () => {
@@ -111,6 +113,109 @@ describe("replaceImageRefs", () => {
     expect(result).toBe(
       "text ![hero](asset://blog/post-1/hero.png) more ![diag](asset://blog/post-1/diag.jpg) end"
     );
+  });
+});
+
+describe("resolveImageFieldNames", () => {
+  const baseProps: ModelDefinition["properties"] = [
+    {
+      propertyName: "title",
+      dataType: "string",
+      fieldType: { element: "input" },
+      require: true,
+    },
+    {
+      propertyName: "content",
+      dataType: "string",
+      fieldType: { element: "markdown" },
+    },
+  ];
+
+  it("auto-recognizes asset dataType fields with mediaType image", () => {
+    const model: ModelDefinition = {
+      id: "blog",
+      modelName: "blog",
+      properties: [
+        ...baseProps,
+        {
+          propertyName: "cover",
+          dataType: "asset",
+          mediaType: "image",
+          require: true,
+        },
+        { propertyName: "thumb", dataType: "asset", mediaType: "image" },
+      ],
+    };
+    const names = resolveImageFieldNames(model);
+    expect([...names].sort()).toEqual(["cover", "thumb"]);
+  });
+
+  it("merges asset auto-recognition with legacy imageFields", () => {
+    const model: ModelDefinition = {
+      id: "blog",
+      modelName: "blog",
+      properties: [
+        ...baseProps,
+        {
+          propertyName: "cover",
+          dataType: "asset",
+          mediaType: "image",
+          require: true,
+        },
+        {
+          propertyName: "legacyHero",
+          dataType: "string",
+          fieldType: { element: "input" },
+        },
+      ],
+    };
+    const names = resolveImageFieldNames(model, ["legacyHero"]);
+    expect([...names].sort()).toEqual(["cover", "legacyHero"]);
+  });
+
+  it("dedupes when imageFields names an asset field already auto-recognized", () => {
+    const model: ModelDefinition = {
+      id: "blog",
+      modelName: "blog",
+      properties: [
+        ...baseProps,
+        {
+          propertyName: "cover",
+          dataType: "asset",
+          mediaType: "image",
+          require: true,
+        },
+      ],
+    };
+    const names = resolveImageFieldNames(model, ["cover"]);
+    expect(names.size).toBe(1);
+    expect(names.has("cover")).toBe(true);
+  });
+
+  it("returns the legacy fields verbatim when there are no asset properties", () => {
+    const model: ModelDefinition = {
+      id: "blog",
+      modelName: "blog",
+      properties: [
+        ...baseProps,
+        {
+          propertyName: "thumbnail",
+          dataType: "string",
+          fieldType: { element: "input" },
+        },
+      ],
+    };
+    const names = resolveImageFieldNames(model, ["thumbnail"]);
+    expect([...names]).toEqual(["thumbnail"]);
+  });
+
+  it("returns an empty set when no asset fields and no imageFields", () => {
+    const model: ModelDefinition = {
+      id: "blog",
+      modelName: "blog",
+      properties: baseProps,
+    };
+    expect(resolveImageFieldNames(model).size).toBe(0);
   });
 });
 

--- a/packages/md-importer/src/__tests__/importer.integration.test.ts
+++ b/packages/md-importer/src/__tests__/importer.integration.test.ts
@@ -364,4 +364,118 @@ Body text.
 
     await rm(fmDir, { recursive: true, force: true });
   });
+
+  it("auto-recognizes asset dataType fields without imageFields", async () => {
+    const assetDir = path.join(tmpDir, "_asset_auto");
+    await mkdir(assetDir, { recursive: true });
+    await mkdir(path.join(assetDir, "images"), { recursive: true });
+    await writeFile(
+      path.join(assetDir, "asset-post.md"),
+      `---
+title: Asset DataType Post
+cover: ./images/cover.png
+thumbnail: ./images/thumb.png
+publishedAt: 2024-05-01
+---
+
+Body with embedded image: ![inline](./images/inline.png)
+`
+    );
+    await writeFile(
+      path.join(assetDir, "images", "cover.png"),
+      Buffer.from("fake-cover-bytes")
+    );
+    await writeFile(
+      path.join(assetDir, "images", "thumb.png"),
+      Buffer.from("fake-thumb-bytes")
+    );
+    await writeFile(
+      path.join(assetDir, "images", "inline.png"),
+      Buffer.from("fake-inline-bytes")
+    );
+
+    // Note: imageFields is NOT passed; asset dataType should auto-trigger upload.
+    const result = await mdImporter({
+      mdDir: assetDir,
+      modelFile: path.join(FIXTURES, "blog_posts_with_asset.json"),
+      firebaseConfig: { projectId: PROJECT_ID, storageBucket: STORAGE_BUCKET },
+      collection: "asset_auto_posts",
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.imported).toHaveLength(1);
+
+    const firestore = initFirestore({ projectId: PROJECT_ID });
+    const doc = await firestore
+      .collection("asset_auto_posts")
+      .doc("asset-post")
+      .get();
+    expect(doc.exists).toBe(true);
+
+    const data = doc.data()!;
+    expect(data["cover"]).toBe(
+      "asset://blog_posts_asset/asset-post/cover.png"
+    );
+    expect(data["thumbnail"]).toBe(
+      "asset://blog_posts_asset/asset-post/thumb.png"
+    );
+    expect(data["title"]).toBe("Asset DataType Post");
+
+    // Body inline image is still processed by markdown extraction.
+    const content = data["content"] as string;
+    expect(content).toContain(
+      "asset://blog_posts_asset/asset-post/inline.png"
+    );
+
+    // Verify physical uploads in Storage.
+    const appName = `contedra-${PROJECT_ID}`;
+    const app = getApps().find((a) => a.name === appName)!;
+    const bucket = getStorage(app).bucket();
+    for (const fileName of ["cover.png", "thumb.png", "inline.png"]) {
+      const [exists] = await bucket
+        .file(`assets/blog_posts_asset/asset-post/${fileName}`)
+        .exists();
+      expect(exists, `${fileName} should be uploaded`).toBe(true);
+    }
+
+    await rm(assetDir, { recursive: true, force: true });
+  });
+
+  it("skips asset:// URIs already present in frontmatter (idempotent re-import)", async () => {
+    const assetDir = path.join(tmpDir, "_asset_already_uri");
+    await mkdir(assetDir, { recursive: true });
+    await writeFile(
+      path.join(assetDir, "already-uri.md"),
+      `---
+title: Already URI
+cover: asset://existing/already-uri/cover.png
+publishedAt: 2024-05-02
+---
+
+Body.
+`
+    );
+
+    const result = await mdImporter({
+      mdDir: assetDir,
+      modelFile: path.join(FIXTURES, "blog_posts_with_asset.json"),
+      firebaseConfig: { projectId: PROJECT_ID, storageBucket: STORAGE_BUCKET },
+      collection: "asset_already_uri",
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.imported).toHaveLength(1);
+
+    const firestore = initFirestore({ projectId: PROJECT_ID });
+    const doc = await firestore
+      .collection("asset_already_uri")
+      .doc("already-uri")
+      .get();
+    // Pre-existing asset:// URI is preserved verbatim.
+    expect(doc.data()!["cover"]).toBe(
+      "asset://existing/already-uri/cover.png"
+    );
+
+    await rm(assetDir, { recursive: true, force: true });
+  });
 });

--- a/packages/md-importer/src/images.ts
+++ b/packages/md-importer/src/images.ts
@@ -1,8 +1,34 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import type { ModelDefinition } from "@contedra/core";
 
 /** Regex matching Markdown image syntax: ![alt](path) or ![alt](path "title") */
 const IMAGE_REGEX = /!\[([^\]]*)\]\((\S+?)(?:\s+"[^"]*")?\)/g;
+
+/**
+ * Compute the set of frontmatter field names whose values should be uploaded
+ * as image assets. Two sources merge:
+ *   1. asset dataType properties with mediaType "image" (auto-recognized)
+ *   2. explicit `imageFields` (legacy/backward-compat for string-typed fields)
+ *
+ * Other mediaType values (when added: video / audio / file) are intentionally
+ * skipped here — they need their own resolver branch in importer.ts.
+ */
+export function resolveImageFieldNames(
+  model: ModelDefinition,
+  imageFields?: string[]
+): Set<string> {
+  const names = new Set<string>();
+  for (const prop of model.properties) {
+    if (prop.dataType === "asset" && prop.mediaType === "image") {
+      names.add(prop.propertyName);
+    }
+  }
+  if (imageFields?.length) {
+    for (const f of imageFields) names.add(f);
+  }
+  return names;
+}
 
 export interface ImageRef {
   /** Full match string in the Markdown */

--- a/packages/md-importer/src/importer.ts
+++ b/packages/md-importer/src/importer.ts
@@ -14,6 +14,7 @@ import {
   assetStoragePath,
   assetUri,
   replaceImageRefs,
+  resolveImageFieldNames,
 } from "./images.js";
 
 /**
@@ -92,11 +93,26 @@ export async function mdImporter(
         processedBody = replaceImageRefs(body, replacements);
       }
 
-      // Process frontmatter image fields
-      if (!config.noImages && bucket && config.imageFields?.length) {
-        for (const fieldName of config.imageFields) {
+      // Process frontmatter image fields. Sources merge: asset dataType
+      // (auto-recognized) + explicit --image-fields (legacy compat).
+      if (!config.noImages && bucket) {
+        const imageFieldNames = resolveImageFieldNames(
+          model,
+          config.imageFields
+        );
+
+        for (const fieldName of imageFieldNames) {
           const value = data[fieldName];
           if (typeof value !== "string" || !value) continue;
+          // Skip values that already are URIs (asset:// or http(s)://) — they're
+          // already-resolved references and should pass through unchanged.
+          if (
+            value.startsWith("asset://") ||
+            value.startsWith("http://") ||
+            value.startsWith("https://")
+          ) {
+            continue;
+          }
 
           const fileName = path.basename(value);
           const storagePath = assetStoragePath(


### PR DESCRIPTION
## Summary

Adds `dataType: "asset"` end-to-end support to the downstream packages, completing the work started in PR #34 (Issue #33) which introduced asset support in `@contedra/core`'s schema/valibot only.

- `@contedra/md-importer`: `dataType: "asset"` frontmatter fields are now auto-uploaded and rewritten to `asset://` URIs without needing `--image-fields`.
- `@contedra/astro-loader-firestore`: asset fields are typed as `z.string()` (resolved URL string) and continue to flow through the existing `assets: { mode: "url" | "download" }` resolver.
- `@contedra/core`: minimal additive completion of PR #34 — TS types and `dataTypeToZod` / `convertValue` cases for asset.

> **Note:** PR #34 (Issue #33) introduced `AssetPropertySchema` to the JSON Schema and valibot, but `packages/core/src/types.ts` (`ModelProperty` union) and `dataTypeToZod` / `convertValue` were missed at that time. This PR includes a minimal additive (~15-line) carry of those completions in `@contedra/core` so that downstream packages can branch on `dataType: "asset"` in a type-safe way. Issue #35 originally said "core unchanged"; the discovery is documented under "Findings" below and was confirmed with the leader.

## Findings (Step 1 investigation)

### `@contedra/md-importer@0.4.0`
- `loadModel()` does not run schema validation; `dataType: "asset"` properties pass through.
- `mapFields()` falls through asset values unchanged (as if `string`).
- `--image-fields cover` happened to work for asset-typed fields by coincidence — it checks only that the value is a `string`, not the property's `dataType`. There was **no auto-recognition** of `dataType: "asset"`.

### `@contedra/astro-loader-firestore@0.4.0`
- Same: no schema validation, asset values pass through.
- `assets: { mode: "download" }` already worked for asset fields because the resolver walks every string in the document via `replaceAssetUrisInRecord` / `collectAssetUrisFromRecord` — it is `dataType`-agnostic.
- Type inference: `dataTypeToZod` returned `z.unknown().optional()` for asset (default fallthrough), so `getCollection().data.cover` was typed as `unknown` instead of `string`.

### `@contedra/core@0.4.0` (PR #34 carry surface)
- `AssetPropertySchema` shipped in valibot and JSON Schema 1.1.0.
- `ModelProperty` TS union, `dataTypeToZod`, and `convertValue` all missing the asset case.

## Changes

### `@contedra/core` (minimal additive, breaking-change-free)
- `types.ts`: added `MediaType` type and `AssetProperty` interface, extended `ModelProperty` union.
- `schema.ts`: `dataTypeToZod` returns `z.string()` for `asset`.
- `firestore.ts`: `convertValue` returns the string value (or `String(value)` fallback) for `asset`.
- `index.ts`: re-exports `AssetProperty` and `MediaType`.

### `@contedra/md-importer`
- New helper `resolveImageFieldNames(model, imageFields?)` in `images.ts` merges:
  1. `dataType: "asset"` properties with `mediaType: "image"` (auto-recognized).
  2. Explicit `--image-fields` (legacy path for `dataType: "string"` fields).
- `importer.ts` uses the helper. Values that already are URIs (`asset://`, `http://`, `https://`) are skipped (idempotent re-import).
- MVP: only `mediaType: "image"` triggers upload — future `video` / `audio` / `file` will need their own resolver branch; until then they're rejected by the `@contedra/core` schema validation upstream.
- Backward compat: `--image-fields` for `string`-typed fields is unchanged. Combined use deduplicates.

### `@contedra/astro-loader-firestore`
- **No code change in `loader.ts`.** Existing `replaceAssetUrisInRecord` walks all string values, so `asset://` URIs in asset fields were already resolved transparently. This PR only adds tests verifying that behavior holds for asset dataType fields and that schema delegates to the (now-improved) `buildSchema`.
- Type inference improvement comes for free via `@contedra/core`'s `dataTypeToZod` change.

### Documentation
- `md-importer/README.md`: new "Frontmatter Image Fields" section contrasting `dataType: "asset"` (recommended, auto-recognized) vs. legacy `--image-fields`. mediaType `"image"` MVP note included.
- `astro-loader-firestore/README.md`: data-type table includes `asset → z.string()`; new "asset dataType vs. legacy `--image-fields`" comparison table.

## Test plan

- [x] `pnpm build` clean (3 packages)
- [x] `pnpm lint` clean (warnings present are pre-existing on `core/__tests__/assets.integration.test.ts` and `md-importer/__tests__/cli.test.ts`)
- [x] `pnpm test` (unit + emulator-driven core tests): 175 tests pass — core 128 / md-importer 37 / astro-loader 10
  - core: new asset cases in `schema.test.ts` (2) + `firestore.test.ts` (1)
  - md-importer: new `resolveImageFieldNames` unit tests (5) covering auto-recognize, legacy merge, dedup, legacy-only, empty
  - astro-loader-firestore: new asset dataType field test + schema delegation test
- [x] `pnpm test:integration` for md-importer (asset auto-upload round-trip + idempotent re-import + 7 regression tests): 9 tests pass

### How to run integration tests locally

The repo's root `firebase.json` only configures the storage emulator (port 9299), so running `pnpm test:integration` for `md-importer` from the package directory leaves Firestore unreachable and all tests time out. Borrow the `demo/` package's `firebase.json` (which configures both Firestore on 8080 and Storage on 9199):

```bash
cd demo
npx firebase emulators:exec --only firestore,storage --project demo-md-importer \
  "cd ../packages/md-importer && pnpm test:integration"
```

> Possible future chore (CTO 室 judgment): add Firestore to root `firebase.json` so package-level integration commands work standalone. Out of scope for this PR.

## Versioning

Per `CLAUDE.md`, package versions are **not bumped in this PR**. The release script (`./scripts/release.sh minor`) will bump every package together post-merge.

**Next release:** `./scripts/release.sh minor` → 0.4.0 → **0.5.0** (md-importer, astro-loader-firestore, core).

## Related

- Upstream: contedra/toolkit#28 (manifest), #31 (manifest valibot), #33 (asset dataType / core)
- Downstream consumer: CircleAround/corporate-website (planned cover/avatar migration after this PR ships)
- Parallel: CircleAround/conteditor#1437 (image picker UI; CTO 室 owned, independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `asset` data type for model properties with media type support (currently images).
  * Asset fields automatically resolve `asset://` URIs to plain URL strings in templates.
  * Added auto-detection of asset fields in markdown imports, with fallback to legacy `--image-fields` option.

* **Documentation**
  * Updated README documentation for asset data type mapping and image field handling.

* **Tests**
  * Added comprehensive test coverage for asset field processing and schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->