### PR TITLE
chore: add pnpm package age gate for supply chain mitigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,23 @@ A demo Astro project is included in the [`demo/`](./demo) directory. It uses the
 
 ## Development
 
+### Prerequisites
+
+This repo enforces a minimum pnpm version so that the supply-chain age gate
+(see below) is always active. The required version is pinned via the
+`packageManager` and `engines.pnpm` fields in `package.json`.
+
+```bash
+# Use the pinned pnpm version automatically (recommended)
+corepack enable
+
+# Verify the active version satisfies the requirement (>= 11.0.0)
+pnpm --version
+```
+
+With `engineStrict` enabled, `pnpm install` fails if the active pnpm version
+does not satisfy `engines.pnpm`.
+
 ```bash
 # Install dependencies
 pnpm install
@@ -202,6 +219,37 @@ pnpm test
 # Lint
 pnpm lint
 ```
+
+### Supply chain age gate
+
+To reduce the risk of installing a compromised package right after a malicious
+release, `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (minutes = 7
+days). pnpm will not install any dependency version — including transitive
+ones — until it has been public for that long. Most malicious releases are
+detected and removed from the registry within hours.
+
+Verify the setting is active:
+
+```bash
+pnpm config get minimumReleaseAge   # -> 10080
+pnpm config get engineStrict        # -> true
+```
+
+#### Temporarily bypassing the gate (security fixes)
+
+When a CVE fix has just been published and you must take it before the age
+window elapses, override the gate **per-command** without editing the config
+files:
+
+```bash
+pnpm add <pkg> --config.minimumReleaseAge=0
+# or for a full install
+pnpm install --config.minimumReleaseAge=0
+```
+
+Do not change `pnpm-workspace.yaml` for this. When bypassing, record the
+reason (e.g. the CVE number) in the PR and commit message so reviewers know
+why a fresh package version was pulled in.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -242,9 +242,9 @@ window elapses, override the gate **per-command** without editing the config
 files:
 
 ```bash
-pnpm add <pkg> --config.minimumReleaseAge=0
+pnpm add <pkg> --config.minimum-release-age=0
 # or for a full install
-pnpm install --config.minimumReleaseAge=0
+pnpm install --config.minimum-release-age=0
 ```
 
 Do not change `pnpm-workspace.yaml` for this. When bypassing, record the

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "version:minor": "pnpm -r exec -- npm version minor --no-git-tag-version && node -e \"const p=require('./packages/core/package.json'); console.log('v'+p.version)\"",
     "version:major": "pnpm -r exec -- npm version major --no-git-tag-version && node -e \"const p=require('./packages/core/package.json'); console.log('v'+p.version)\""
   },
-  "packageManager": "pnpm@10.32.1",
+  "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499",
+  "engines": {
+    "pnpm": ">=11.0.0"
+  },
   "devDependencies": {
     "firebase-tools": "^13.35.1"
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,16 @@ minimumReleaseAge: 10080
 
 # Fail install if the active pnpm version does not satisfy engines.pnpm.
 engineStrict: true
+
+# pnpm v11 fails the install (ERR_PNPM_IGNORED_BUILDS) when a dependency
+# ships a build/postinstall script that is not explicitly listed here.
+# These are kept disabled: the build/test pipeline already passed without
+# them under pnpm 10, and not running unreviewed postinstall scripts is
+# consistent with the supply-chain hardening in this file. A new dependency
+# that adds a build script will fail CI until it is reviewed and listed.
+allowBuilds:
+  '@firebase/util': false
+  esbuild: false
+  protobufjs: false
+  re2: false
+  sharp: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
 packages:
   - 'packages/*'
   - 'demo'
+
+# Supply chain attack mitigation: delay installing newly published
+# packages. minimumReleaseAge is in minutes; 10080 = 7 days. Applies to
+# all dependencies including transitive ones. (pnpm >= 10.16.0)
+minimumReleaseAge: 10080
+
+# Fail install if the active pnpm version does not satisfy engines.pnpm.
+engineStrict: true


### PR DESCRIPTION
## Summary

Adds a supply-chain age gate so that newly published package versions
(including transitive dependencies) are not installed until they have been
public for **7 days**. Most malicious npm releases are detected and removed
from the registry within hours, so this closes the riskiest window.

pnpm v11 reads `minimumReleaseAge` / `engineStrict` from
`pnpm-workspace.yaml` (not `.npmrc`, which is auth/registry only).

### Changed files & values

| File | Setting | Value |
|------|---------|-------|
| `pnpm-workspace.yaml` | `minimumReleaseAge` | `10080` (minutes = 7 days) |
| `pnpm-workspace.yaml` | `engineStrict` | `true` |
| `package.json` | `engines.pnpm` | `">=11.0.0"` |
| `package.json` | `packageManager` | `pnpm@11.1.2` (corepack integrity hash) |
| `README.md` | — | Documents requirement, corepack, bypass procedure |

Scope: pnpm monorepo only (root + `packages/*` + `demo`). No npm/yarn/bun
usage in the repo. `pnpm-lock.yaml` is unchanged — all current deps were
published more than 7 days ago, so nothing downgraded.

### Notes for existing members

- A minimum pnpm version is now enforced. Run `corepack enable` to pick up
  the pinned `pnpm@11.1.2` automatically. With `engineStrict`, `pnpm install`
  fails on pnpm < 11.0.0.
- To take an urgent security fix before the 7-day window, override
  per-command instead of editing config:
  `pnpm add <pkg> --config.minimumReleaseAge=0`. Record the reason (CVE)
  in the PR/commit.

### Follow-up (out of scope)

CI uses `pnpm/action-setup@v4`; it reads `packageManager` from
`package.json`, so it should pick up pnpm 11 automatically — worth confirming
on the first CI run of this PR.

## Test plan

- [ ] `pnpm config get minimumReleaseAge` → `10080`
- [ ] `pnpm config get engineStrict` → `true`
- [ ] `pnpm --version` → `>= 11.0.0` via corepack
- [ ] `pnpm install` succeeds with no `pnpm-lock.yaml` diff
- [ ] CI (`Test` workflow) passes with pnpm 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum pnpm version requirement to 11.0.0+
  * Added supply chain security validation requiring dependencies to be at least 7 days old
  * Enabled stricter pnpm version enforcement during package installation

* **Documentation**
  * Updated development guide with new prerequisites and configuration details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/contedra/toolkit/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->